### PR TITLE
Add correction to javaDoc for BuildResult class (Fix #52)

### DIFF
--- a/app/src/main/java/org/example/BuildResult.java
+++ b/app/src/main/java/org/example/BuildResult.java
@@ -19,12 +19,19 @@ public class BuildResult{
 
     /**
      * status: the final status of the build/test
+     */
+    public Status status;
+
+    /**
      * logs: the standard output/error logs captured during execution.
+     */
+
+    public String logs;
+
+    /**
      * errorMessage: a descriptive error message if an error occurred.
      */
 
-    public Status status;
-    public String logs;
     public String errorMessage;
 
     public BuildResult(Status status) {


### PR DESCRIPTION
Add correction to javaDoc for BuildResult class in order to have a correct API documentation format (Fix #52)